### PR TITLE
Add custom-widget, data-models

### DIFF
--- a/examples/custom-widget.rs
+++ b/examples/custom-widget.rs
@@ -1,0 +1,55 @@
+use kas::prelude::*;
+use kas::widgets::{format_value, AccessLabel, Button, Row, Text};
+
+#[derive(Clone, Debug)]
+struct Increment(i32);
+
+impl_scope! {
+    #[widget{
+        layout = column![
+            align!(center, self.display),
+            self.buttons,
+        ];
+    }]
+    struct Counter {
+        core: widget_core!(),
+        #[widget(&self.count)]
+        display: Text<i32, String>,
+        #[widget]
+        buttons: Row<Button<AccessLabel>>,
+        count: i32,
+    }
+    impl Self {
+        fn new(count: i32) -> Self {
+            Counter {
+                core: Default::default(),
+                display: format_value!("{}"),
+                buttons: Row::new([
+                    Button::label_msg("-", Increment(-1)),
+                    Button::label_msg("+", Increment(1)),
+                ]),
+                count,
+            }
+        }
+    }
+    impl Events for Self {
+        type Data = ();
+
+        fn handle_messages(&mut self, cx: &mut EventCx, data: &()) {
+            if let Some(Increment(incr)) = cx.try_pop() {
+                self.count += incr;
+                cx.update(self.as_node(data));
+            }
+        }
+    }
+}
+
+fn main() -> kas::app::Result<()> {
+    env_logger::init();
+
+    let theme = kas::theme::SimpleTheme::new().with_font_size(24.0);
+    kas::app::Default::with_theme(theme)
+        .build(())?
+        .with(Window::new(Counter::new(0), "Counter"))
+        .run()
+}

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -6,3 +6,4 @@
 - [Sync-counter: Adapt'ing AppData](sync-counter.md)
 - [Calculator: make_widget and grid](calculator.md)
 - [Custom widgets](custom-widget.md)
+- [Data models](data-models.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -5,3 +5,4 @@
 - [Counter: an interactive widget](counter.md)
 - [Sync-counter: Adapt'ing AppData](sync-counter.md)
 - [Calculator: make_widget and grid](calculator.md)
+- [Custom widgets](custom-widget.md)

--- a/src/calculator.md
+++ b/src/calculator.md
@@ -211,7 +211,7 @@ let buttons = kas::grid! {
 
 Worth noting is our hidden `Backspace` button. This is just another cell, but hidden under the `clear` button. Yes, this is a sub-optimal hack (the widget is still sized and drawn); it works but might see a less hacky solution in the future.
 
-Again, we must use [`map_any`] to make our buttons (input `Data = ()`) compatible with the parent UI element (input `Data = Calculator`).
+Again, we use <code>.[map_any][]()</code> to make our buttons (input `Data = ()`) compatible with the parent UI element (input `Data = Calculator`).
 
 
 [`Key`]: https://docs.rs/kas/latest/kas/event/enum.Key.html
@@ -223,4 +223,4 @@ Again, we must use [`map_any`] to make our buttons (input `Data = ()`) compatibl
 [`disable_nav_focus`]: https://docs.rs/kas/latest/kas/event/struct.ConfigCx.html#method.disable_nav_focus
 [`enable_alt_bypass`]: https://docs.rs/kas/latest/kas/event/struct.EventState.html#method.enable_alt_bypass
 [`kas::grid!`]: https://docs.rs/kas/latest/kas/macro.grid.html
-[`map_any`]: https://docs.rs/kas/latest/kas/widgets/trait.AdaptWidgetAny.html#method.map_any
+[map_any]: https://docs.rs/kas/latest/kas/widgets/trait.AdaptWidgetAny.html#method.map_any

--- a/src/counter.md
+++ b/src/counter.md
@@ -92,7 +92,7 @@ let tree = kas::column![
 Now, you could, if you prefer, import the layout macros: `use kas::{align, column, row};`. *However,*
 
 -   (`std`) [`column!`](https://doc.rust-lang.org/stable/std/macro.column.html) is a *very* different macro. This can result in surprising error messages if you forget to import `kas::column`.
--   If you replace `kas::row!` with `row!` you will get a compile error: the layout macro parser cannot handle <code>.[map_any](https://docs.rs/kas/latest/kas/widgets/trait.AdaptWidgetAny.html#method.map_any)()</code>. `kas::row![..]` evaluates to a complete widget; `row![..]` as an embedded layout does not.
+-   If you replace `kas::row!` with `row!` you will get a compile error: the layout macro parser cannot handle <code>.[map_any][]()</code>. `kas::row![..]` evaluates to a complete widget; `row![..]` as an embedded layout does not.
 
 
 ## Input data
@@ -131,11 +131,11 @@ But to make this *do something* we need one more concept: *messages*.
 
 ### Mapping data
 
-We should briefly justify `.map_any()` in our example: our [`Text`] widget expects input data (of type `i32`), while `Button::label_msg` constructs a <code>[Button](https://docs.rs/kas/latest/kas/widgets/struct.Button.html)\<[AccessLabel](https://docs.rs/kas/latest/kas/widgets/struct.AccessLabel.html)\></code> expecting data of type `()`.
+We should briefly justify `.map_any()` in our example: our [`Text`] widget expects input data (of type `i32`), while [`Button::label_msg`] constructs a <code>[Button][]\<[AccessLabel][]\></code> expecting data of type `()`.
 
-The method <code>.[map_any](https://docs.rs/kas/latest/kas/widgets/trait.AdaptWidgetAny.html#method.map_any)()</code> maps the row of buttons to a new widget supporting (and ignoring) *any* input data.
+The method <code>.[map_any][]()</code> maps the row of buttons to a new widget supporting (and ignoring) *any* input data.
 
-We could instead use <code>Button::new([label_any](https://docs.rs/kas/latest/kas/widgets/fn.label_any.html)("+"))</code> which serves the same purpose, but ignoring that input data much further down the tree.
+We could instead use <code>[Button][]::new([label_any][]("+"))</code> which serves the same purpose, but ignoring that input data much further down the tree.
 
 
 ## Messages
@@ -165,7 +165,7 @@ Use of built-in types like `()` or `i32` is possible but considered bad practice
 
 ### Buttons
 
-This should be obvious: `Button::label_msg("+", Increment(1))` constructs a [`Button`] which pushes the message `Increment(1)` when pressed.
+This should be obvious: `Button::label_msg("+", Increment(1))` constructs a [`Button`][Button] which pushes the message `Increment(1)` when pressed.
 
 ### Handling messages
 
@@ -184,6 +184,7 @@ Adapt::new(tree, 0)
 ```
 [`Adapt::on_message`] calls our closure whenever an `Increment` message is pushed with a mutable reference to its state, `count`. After handling our message, [`Adapt`] will update its descendants with the new value of `count`, thus refreshing the label: `format_value!("{}"))`.
 
+[map_any]: https://docs.rs/kas/latest/kas/widgets/trait.AdaptWidgetAny.html#method.map_any
 [`kas::prelude`]: https://docs.rs/kas/latest/kas/prelude/index.html
 [`kas::column!`]: https://docs.rs/kas/latest/kas/macro.column.html
 [`kas::row!`]: https://docs.rs/kas/latest/kas/macro.row.html
@@ -196,5 +197,8 @@ Adapt::new(tree, 0)
 [`kas::event`]: https://docs.rs/kas/latest/kas/event/index.html
 [`push`]: https://docs.rs/kas/latest/kas/event/struct.EventCx.html#method.push
 [`try_pop`]: https://docs.rs/kas/latest/kas/event/struct.EventCx.html#method.try_pop
-[`Button`]: https://docs.rs/kas/latest/kas/widgets/struct.Button.html
+[Button]: https://docs.rs/kas/latest/kas/widgets/struct.Button.html
 [`Adapt::on_message`]: https://docs.rs/kas/latest/kas/widgets/struct.Adapt.html#method.on_message
+[AccessLabel]: https://docs.rs/kas/latest/kas/widgets/struct.AccessLabel.html
+[label_any]: https://docs.rs/kas/latest/kas/widgets/fn.label_any.html
+[`Button::label_msg`]: https://docs.rs/kas/latest/kas/widgets/struct.Button.html#method.label_msg

--- a/src/custom-widget.md
+++ b/src/custom-widget.md
@@ -1,0 +1,221 @@
+# Counter: a simple widget
+
+*Topics: custom widgets*
+
+![Counter](screenshots/counter.png)
+
+Here we rewrite the counter as a custom widget. There's no reason to do so for this particular case, but it serves as a simple example to the topic.
+
+```rust
+# extern crate kas;
+use kas::prelude::*;
+use kas::widgets::{format_value, AccessLabel, Button, Row, Text};
+
+#[derive(Clone, Debug)]
+struct Increment(i32);
+
+impl_scope! {
+    #[widget{
+        layout = column![
+            align!(center, self.display),
+            self.buttons,
+        ];
+    }]
+    struct Counter {
+        core: widget_core!(),
+        #[widget(&self.count)]
+        display: Text<i32, String>,
+        #[widget]
+        buttons: Row<Button<AccessLabel>>,
+        count: i32,
+    }
+    impl Self {
+        fn new(count: i32) -> Self {
+            Counter {
+                core: Default::default(),
+                display: format_value!("{}"),
+                buttons: Row::new([
+                    Button::label_msg("-", Increment(-1)),
+                    Button::label_msg("+", Increment(1)),
+                ]),
+                count,
+            }
+        }
+    }
+    impl Events for Self {
+        type Data = ();
+
+        fn handle_messages(&mut self, cx: &mut EventCx, data: &()) {
+            if let Some(Increment(incr)) = cx.try_pop() {
+                self.count += incr;
+                cx.update(self.as_node(data));
+            }
+        }
+    }
+}
+
+fn main() -> kas::app::Result<()> {
+    env_logger::init();
+
+    let theme = kas::theme::SimpleTheme::new().with_font_size(24.0);
+    kas::app::Default::with_theme(theme)
+        .build(())?
+        .with(Window::new(Counter::new(0), "Counter"))
+        .run()
+}
+```
+
+## Macros
+
+### `impl_scope`
+
+[`impl_scope!`] is a macro from [impl-tools]. This macro wraps a type definition and `impl`s on that type. (Unfortunately it also inhibits `rustfmt` from working, [for now](https://github.com/rust-lang/rustfmt/pull/5538).)  Here, it serves two purposes:
+
+1.  `impl Self` syntax (not important here, but much more useful on structs with generics)
+2.  To support the [`#[widget]`][attr-widget] attribute-macro. This attribute-macro is a Kas extension to [`impl_scope!`], and can act on anything within that scope (namely, it will check existing impls of [`Layout`], [`Events`] and [`Widget`], reading definitions of associated `type Data`, injecting certain missing methods into these impls, and write new impls).
+
+### `#[widget]`
+
+The [`#[widget]`][attr-widget] attribute-macro is used to implement the [`Widget`] trait. *This is the only supported way to implement [`Widget`].* There are a few parts to this.
+
+**First**, we must apply [`#[widget]`][attr-widget] to the struct. (The `layout = ...;` argument (and `{ ... }` braces) are optional; some other arguments might also occur here.)
+```ignore
+    #[widget{
+        layout = column![
+            align!(center, self.display),
+            self.buttons,
+        ];
+    }]
+```
+
+**Second**, all widgets must have "core data". This *might* be an instance of [`CoreData`] or *might* be some custom generated struct (but with the same public `rect` and `id` fields and constructible via [`Default`]). We *must* provide a field of type `widget_core!()`.
+```ignore
+        core: widget_core!(),
+```
+
+**Third**, any fields which are child widgets must be annotated with `#[widget]`. (This enables them to be configured and updated.)
+
+We can use this attribute to configure the child widget's input data too: in this case, `display` is passed `&self.count`. Beware only that there is no automatic update mechanism: when mutating a field used as input data it may be necessary to explicitly update the affected widget(s) (see the note after the fourth step below).
+```rust
+# extern crate kas;
+# use kas::impl_scope;
+# use kas::widgets::{AccessLabel, Button, Row, Text};
+# impl_scope! {
+#     #[widget{
+#         Data = ();
+#         layout = "";
+#     }]
+    struct Counter {
+        core: widget_core!(),
+        #[widget(&self.count)]
+        display: Text<i32, String>,
+        #[widget]
+        buttons: Row<Button<AccessLabel>>,
+        count: i32,
+    }
+# }
+```
+
+**Fourth**, the input `Data` type to our `Counter` widget must be specified somewhere. In our case, we specify this by implementing [`Events`]. (If this trait impl was omitted, you could write `Data = ();` as an argument to [`#[widget]`][attr-widget].)
+```rust
+# extern crate kas;
+# use kas::prelude::*;
+# #[derive(Clone, Debug)]
+# struct Increment(i32);
+# impl_scope! {
+#     #[widget{
+#         layout = "";
+#     }]
+#     struct Counter {
+#         core: widget_core!(),
+#         count: i32,
+#     }
+    impl Events for Self {
+        type Data = ();
+
+        fn handle_messages(&mut self, cx: &mut EventCx, data: &()) {
+            if let Some(Increment(incr)) = cx.try_pop() {
+                self.count += incr;
+                cx.update(self.as_node(data));
+            }
+        }
+    }
+# }
+```
+
+Notice here that after mutating `self.count` we call `cx.update(self.as_node(data))` in order to update `self` (and all children recursively). (In this case it would suffice to update only `display`, e.g. via `cx.update(self.display.as_node(&self.count))`, if you prefer to trade complexity for slightly more efficient code.)
+
+**Fifth**, we must specify widget layout somehow. There are two main ways of doing this: implement [`Layout`] or use the `layout` argument of [`#[widget]`][attr-widget]. To recap, we use:
+```ignore
+    #[widget{
+        layout = column![
+            align!(center, self.display),
+            self.buttons,
+        ];
+    }]
+```
+This is macro-parsed layout syntax (not real macros). Don't use [`kas::column!`] here; it won't know what `self.display` is!
+
+Don't worry about remembering each step; macro diagnostics should point you in the right direction. Detection of fields which are child widgets is however imperfect (nor can it be), so try to at least remember to apply `#[widget]` attributes.
+
+### Aside: child widget type
+
+Our `Counter` has two (explicit) child widgets, and we must specify the type of each:
+```rust
+# extern crate kas;
+# use kas::impl_scope;
+# use kas::widgets::{AccessLabel, Button, Row, Text};
+# impl_scope! {
+#     #[widget{
+#         Data = ();
+#         layout = "";
+#     }]
+#     struct Counter {
+#         core: widget_core!(),
+        #[widget(&self.count)]
+        display: Text<i32, String>,
+        #[widget]
+        buttons: Row<Button<AccessLabel>>,
+#         count: i32,
+#     }
+# }
+```
+Here, this is no problem (though note that we used `Row::new([..])` not `kas::row![..]` specifically to have a known widget type). In other cases, widget types can get hard (or even impossible) to write.
+
+It would therefore be nice if we could just write `impl Widget<Data = ()>` in these cases and be done. Alas, Rust does not support this. We are not completely without options however:
+
+-   We could define our `buttons` directly within `layout` instead of as a field. Alas, this doesn't work when passing a field as input data (as used by `display`), or when code must refer to the child by name.
+-   We could box the widget with `Box<dyn Widget<Data = ()>>`. (This is what the `layout` syntax does for embedded widgets.)
+-   The [`impl_anon!`] macro *does* support `impl Trait` syntax. The required code is unfortunately a bit hacky (hidden type generics) and might sometimes cause issues.
+-   It looks likely that Rust will stabilise support for [`impl Trait` in type aliases](https://doc.rust-lang.org/nightly/unstable-book/language-features/type-alias-impl-trait.html) "soon". This requires writing a type-def outside of the widget definition but is supported in nightly:
+
+    ```rust,ignore
+    type MyButtons = impl Widget<Data = ()>;
+    ```
+
+### Aside: uses
+
+Before Kas 0.14, *all* widgets were custom widgets. (Yes, this made simple things hard.)
+
+In the future, custom widgets *might* become obsolete, or might at least change significantly.
+
+But for now, custom widgets still have their uses:
+
+-   Anything with a custom [`Layout`] implementation. E.g. if you want some custom graphics, you can either use [`kas::resvg::Canvas`] or a custom widget.
+-   Child widgets as named fields allows direct read/write access on these widgets. For example, instead of passing a [`Text`] widget the count to display via input data, we *could* use a simple [`Label`] widget and re-write it every time `count` changes.
+-   `Adapt` is the "standard" way of storing local state, but as seen here custom widgets may also do so, and you may have good reasons for this (e.g. to provide different data to different children without lots of mapping).
+-   Since *input data* is a new feature, there are probably some cases it doesn't support yet. One notable example is anything requring a lifetime.
+
+[`impl_scope!`]: https://docs.rs/impl-tools/latest/impl_tools/macro.impl_scope.html
+[`impl_anon!`]: https://docs.rs/impl-tools/latest/impl_tools/macro.impl_anon.html
+[attr-widget]: https://docs.rs/kas/latest/kas/attr.widget.html
+[`Widget`]: https://docs.rs/kas/latest/kas/trait.Widget.html
+[`Events`]: https://docs.rs/kas/latest/kas/trait.Events.html
+[`kas::column!`]: https://docs.rs/kas/latest/kas/macro.column.html
+[`Default`]: https://doc.rust-lang.org/stable/std/default/trait.Default.html
+[`Layout`]: https://docs.rs/kas/latest/kas/trait.Layout.html
+[impl-tools]: https://crates.io/crates/impl-tools
+[`CoreData`]: https://docs.rs/kas/latest/kas/struct.CoreData.html
+[`Label`]: https://docs.rs/kas/latest/kas/widgets/struct.Label.html
+[`Text`]: https://docs.rs/kas/latest/kas/widgets/struct.Text.html
+[`kas::resvg::Canvas`]: https://docs.rs/kas/latest/kas/resvg/struct.Canvas.html

--- a/src/data-models.md
+++ b/src/data-models.md
@@ -1,0 +1,25 @@
+# Sync-counter: data models
+
+*Topics: data models and view widgets*
+
+TODO:
+
+-   [`ListView`] and [`ListData`]
+-   [`Driver`], including predefined impls
+-   [`Filter`] and [`UnsafeFilteredList`]. This rather messy to use (improvable?). The latter should eventually be replaced with a safe variant.
+-   [`MatrixView`] and [`MatrixData`]. (Will possibly gain support for row/column labels and be renamed `TableView`.)
+
+For now, see the examples:
+
+-   [`examples/ldata-list-view.rs`](https://github.com/kas-gui/kas/blob/master/examples/data-list-view.rs) uses [`ListView`] with custom [`ListData`] and [`Driver`]
+-   [`examples/gallery.rs`](https://github.com/kas-gui/kas/blob/master/examples/gallery.rs#L338)'s `filter_list` uses [`UnsafeFilteredList`] with a custom [`Driver`]. Less code but possibly more complex.
+-   [`examples/times-tables.rs`](https://github.com/kas-gui/kas/blob/master/examples/times-tables.rs) uses [`MatrixView`] with custom [`MatrixData`] and [`driver::NavView`]. Probably the easiest example.
+
+[`ListView`]: https://docs.rs/kas/latest/kas/view/struct.ListView.html
+[`ListData`]: https://docs.rs/kas/latest/kas/view/trait.ListData.html
+[`Driver`]: https://docs.rs/kas/latest/kas/view/trait.Driver.html
+[`driver::NavView`]: https://docs.rs/kas/latest/kas/view/driver/struct.NavView.html
+[`Filter`]: https://docs.rs/kas/latest/kas/view/filter/trait.Filter.html
+[`UnsafeFilteredList`]: https://docs.rs/kas/latest/kas/view/filter/struct.UnsafeFilteredList.html
+[`MatrixView`]: https://docs.rs/kas/latest/kas/view/struct.MatrixView.html
+[`MatrixData`]: https://docs.rs/kas/latest/kas/view/trait.MatrixData.html


### PR DESCRIPTION
Convert the old `Counter` tutorial into a custom-widget tutorial (simplified).

Add a stub with some pointers regarding data models.